### PR TITLE
Apply proper cases to integration names

### DIFF
--- a/content/integrations/rabbitmq/_index.md
+++ b/content/integrations/rabbitmq/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "rabbitMQ"
+title: "RabbitMQ"
 #date: 2018-12-12
 draft: false
 tags: ["#rabbitmq", "#integrations" ]

--- a/content/integrations/redis/_index.md
+++ b/content/integrations/redis/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "redis"
+title: "Redis"
 #date: 2018-12-12
 draft: false
 tags: ["#redis", "#integrations" ]


### PR DESCRIPTION
RabbitMQ and Redis are at the bottom of the integrations list because they are written rabbitMQ and redis.