### PR TITLE
Remove references to the AWS Cost datasource

### DIFF
--- a/content/api/api-datasources.md
+++ b/content/api/api-datasources.md
@@ -55,48 +55,6 @@ curl -X POST -k -H 'Authorization: Basic dGVzdDp0ZXN0' -i 'https://api.app.metri
 ]'
 ```
 
-#### AWS Cost Example
-
-```
-curl -X POST -k -H 'Authorization: Basic dGVzdDp0ZXN0' -i 'https://api.app.metricly.com/datasources' --data '[
-{
-  "dataSource": {
-    "id": 47470,
-    "name": “ExampleName”,
-    "type": "AWSCOST",
-    "properties": {
-      "bucketName": "a-bucket-name",
-      "ec2FilterTagType": "include",
-      "ec2FilterTagName": "",
-      "ec2Enabled": "true",
-      "awsAuthentication": "role",
-      "iamRole": "arn:aws:iam::120056789012:role/Metricly-Read-Only-Role-1200567890",
-      "ec2FilterTagValue": ""
-    }
-  }
-}
-]'
-```
-
-**Header**
-
-| Header Name | Header Value |
-|----------------------|---------------------------------------|
-| Content-Type | application/json |
-| Authorization: Basic | (Base64 encoded authentication value) |
-
-**Body Attributes**
-
-| Attribute | Required/Optional | Description |
-|------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| apild | Optional | The API key associated with the integration. |
-| collectors | Optional | The collectors associated with a particular integration. Collectors contains several attributes: datasource (optional) The datasource ID for the datasource the collector is associated with. elements (optional) A comma-delimited list of element IDs that are associated with this collector. id (optional) The ID for the collector. lastSeen (optional) When the collector last sent data. name (optional) The name for the collector. package (optional) The name of the package associated with the collector. packageEnabled (optional) Whether the listed package is enabled. properties (optional) The fields available for the collector (unique to each collector). |
-| deleted | Optional | Whether the integration is deleted. |
-| enabled | Optional | Whether the integration is enabled or not. |
-| name | Optional | The name of the integration (displayed in the Inventory Explorer). |
-| properties | Optional | The fields available for the integration (unique to each integration type). |
-| type | Required | The type of integration. Can be one of the following: AWS, AWS COST, AZURE |
-
 ## GET
 ### GET from /datasources
 Returns a list of all datasources associated with a tenant.

--- a/content/right-sizing/reports-cost.md
+++ b/content/right-sizing/reports-cost.md
@@ -12,13 +12,13 @@ Cost reports enable you to easily identify expensive instances and compare them 
 Cost Reports are generated once per week. It may take up to 7 days before your first report is available.
 
 ## Report Versions
-### Estimated Cost (AWS Integration Only)
-If you just have an AWS integration in Metricly, the Estimated Cost report is available. Instance costs are estimated based on current list prices and simple assumptions to fill in missing information. For a more accurate view including reservations, data transfer costs, iops guarantees and other account specific charges, you can add an AWS Cost integration that allows Metricly to use your actual billing files from AWS.
+### Estimated Cost (AWS CloudWatch Only)
+If you just have an AWS integration in Metricly, the Estimated Cost report is available. Instance costs are estimated based on current list prices and simple assumptions to fill in missing information. For a more accurate view including reservations, data transfer costs, iops guarantees and other account specific charges, you can configure Detailed Billing on your AWS integration which then allows Metricly to use your actual billing files from AWS.
 
 Estimated Cost reports use 7 days of metric results and the current list prices to estimate element instance costs for all instances monitored by Metricly. Estimated Reports do not include data transfer costs and assumes all instances are on-demand.
 
-### Full Cost (AWS+AWS Cost Integration)
-If you have both an AWS and AWS Cost integration, the Full Cost report is available and based on your billing files. The Full Cost report reads 7 days of billing data associated with the instances monitored by Metricly.
+### Full Cost (AWS CloudWatch and Detailed Billing)
+If you have both an AWS integration set up with Detailed Billing configured, the Full Cost report is available and based on your billing files. The Full Cost report reads 7 days of billing data associated with the instances monitored by Metricly.
 
 Costs are aggregated, simplified, and reduced to the following categories element:
 


### PR DESCRIPTION
It has been folded into the regular AWS datasource