### PR TITLE
added subsection in getting started home page about trial datasources

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -7,7 +7,7 @@ tags: ["#getting started", "#directory page",]
 author: Lawrence Lane
 alwaysopen: false
 weight: 1
-pre: 
+pre:
 ---
 
 ![getting-started-header-1](/images/_index/getting-started-header-1.png)
@@ -16,9 +16,9 @@ pre:
 There’s no faster way to get acquainted with the UI than by watching the [demo video][1]. This tour covers both the Cost and Monitoring products, including topics like: the EC2 recommendation report, the Utilization Boxplot report, and the Cost report.
 
 ## 2. Register an Account
-You’re excited to right-size your environments and lower their costs. You’ve done all your research, and you’re ready to try Metricly’s **21-day free trial**. Click Sign Up at the top-right of the page and, after filling out a quick form, you’ll begin to set up Metricly.
+You’re excited to right-size your environments and lower their costs. You’ve done all your research, and you’re ready to try Metricly’s **21-day free trial**. Select Sign Up at the top-right of the page and, after filling out a quick form, you’ll begin to set up Metricly.
 
-#### Whitelist Metricly Emails
+### Whitelist Metricly Emails
 Make sure you’re able to receive all of your emailed reports and notifications by whitelisting ``@metricly.com`` and ``@metriclyinc.com``  This prevents your reports from getting caught in spam filters.
 
 ## 3. Set Up The AWS Integration
@@ -28,7 +28,10 @@ Chances are, you’re going to want to start with AWS.
 
 We recommend linking your AWS account using the [CloudFormation Method][2] found in our help documentation. It’s fast and gets you ready to pump in billing data. Just run the script, enable AWS Cost Explorer, and you’re ready to start monitoring.
 
-#### This Integration Supports
+### Trial Datasource Limit
+While using the trial version of Metricly you are limited to integrating with **two cloud datasources**.
+
+### This Integration Supports
 {{< icon name="fa-check-square-o" size="large" >}} Cost Reports for EC2, RDS, and S3    
 {{< icon name="fa-check-square-o" size="large" >}} Resource Utilization   
 {{< icon name="fa-check-square-o" size="large" >}} EC2 Recommendation   
@@ -42,7 +45,7 @@ Remember to enable **cost explorer** and **detailed billing** before moving beyo
 {{% /notice %}}
 
 ### 4. Install Agents (Linux, Windows)
-Check out our most popular agents! Click on the links to read their in-depth setup documentation. These agents pull in additional cost metrics and help you take action on report insights. **Using these agents ensures the most accurate cost recommendations**.
+Check out our most popular agents! Select on the links to read their in-depth setup documentation. These agents pull in additional cost metrics and help you take action on report insights. **Using these agents ensures the most accurate cost recommendations**.
 
 - [Linux Agent][3]  
   Quickly deploy and collect metrics with a richer set of metadata, right out of the box. This agent also supports CloudWatch integration.


### PR DESCRIPTION
Added simple subsection on the getting started parent page that states the 2 datasource limit for trials. 