### PR TITLE
moved del ele to inventory folder in capacity monitoring. ordered pgs

### DIFF
--- a/content/capacity-monitoring/inventory/inventory-delete-element.md
+++ b/content/capacity-monitoring/inventory/inventory-delete-element.md
@@ -5,6 +5,7 @@ draft: false
 categories:
 tags: ["#getting started", "#metrics", "#elements", "#maintenance", "#cli", "#inventory page"]
 author: Lawrence Lane
+weight: 6
 ---
 You can delete an element from the [Inventory Explorer page][1]. Deleting an element in Metricly persists only until the next collection cycle **unless** the element is also no longer being _collected_ or _posting_ to Metricly.
 

--- a/content/capacity-monitoring/inventory/inventory-element-detail.md
+++ b/content/capacity-monitoring/inventory/inventory-element-detail.md
@@ -5,6 +5,7 @@ draft: false
 categories:
 tags: ["#getting started", "#metrics", "#elements", "#inventory page"]
 author: Lawrence Lane
+weight: 2
 ---
 
 The Element Detail panel displays tabs for the metric **summary**, **policies**, and **relationships** associated with the selected element.

--- a/content/capacity-monitoring/inventory/inventory-main-navigation.md
+++ b/content/capacity-monitoring/inventory/inventory-main-navigation.md
@@ -5,6 +5,7 @@ draft: false
 categories:
 tags: ["#getting started", "#metrics", "#elements", "#inventory page"]
 author: Lawrence Lane
+weight: 1
 ---
 
 ## Select Filters

--- a/content/capacity-monitoring/inventory/inventory-quickbar-actions.md
+++ b/content/capacity-monitoring/inventory/inventory-quickbar-actions.md
@@ -5,6 +5,7 @@ draft: false
 categories:
 tags: ["#getting started", "#metrics", "#elements", "#bulk actions", "#inventory page" ]
 author: Lawrence Lane
+weight: 3
 ---
 The inventory page allows you to quickly navigate through all of your [elements][1], sort, and perform bulk actions. The Inventory Explorer displays all the elements in your environment that were processed in the last hour. Elements are removed from the elements table roughly seven hours after an associated datasource is disabled.
 

--- a/content/capacity-monitoring/inventory/inventory-sort-elements.md
+++ b/content/capacity-monitoring/inventory/inventory-sort-elements.md
@@ -5,6 +5,7 @@ draft: false
 categories:
 tags: ["#getting started", "#metrics", "#elements", "#inventory page"]
 author: Lawrence Lane
+weight: 4
 ---
 
 Select two or more elements and then click **View Metrics** to open multiple elements on the Metrics page. The Elements table initially has six columns:

--- a/content/capacity-monitoring/inventory/inventory-startstop-maintenance.md
+++ b/content/capacity-monitoring/inventory/inventory-startstop-maintenance.md
@@ -5,6 +5,7 @@ draft: false
 categories:
 tags: ["#getting started", "#metrics", "#elements", "#maintenance", "#cli", "#inventory page"]
 author: Lawrence Lane
+weight:  5
 ---
 
 You can place elements into maintenance mode from the Inventory Explorer or via the Metricly CLI (Command Line Interface). While an element is in maintenance mode, learning for that element is disabled (i.e. no contextual or baseline bands will be displayed) and events will not be generated for the element.

--- a/content/efficiency-benchmarking/efficiency-index.md
+++ b/content/efficiency-benchmarking/efficiency-index.md
@@ -30,6 +30,6 @@ Get a per-instance breakdown of your CPU Utilization across your AWS accounts. T
 
 ## The Efficiency Index
 
-The Efficiency Index generates a score by dividing your total EC2 utilization by the average cost per element. A lower score means better maximization of your cloud budget. 
+The Efficiency Index generates a score by dividing your total EC2 utilization by the average cost per element. A lower score means better maximization of your cloud budget.
 
 ![index score](/images/efficiency-index/index-score.png)


### PR DESCRIPTION
the data-visualizations top tier folder wasn't supposed to exist there (I can't remember how it got there.) I moved its 1 article (delete elements) to capacity monitoring > inventory, where it was supposed to be. 