### PR TITLE
Remove 'Notify' option from the dashboards/widgets

### DIFF
--- a/content/dashboards/widgets/_index.md
+++ b/content/dashboards/widgets/_index.md
@@ -46,9 +46,6 @@ This guide includes a list of all **widget types** available, their **options**,
 2. Click **Delete Widget**.
 3. Confirm by clicking **Yes, Delete**.
 
-### Notify
-Receive daily or weekly emails that snapshot widget data (limited to the table widget).
-
 
 [1]:/capacity-monitoring/inventory/
 [2]:/capacity-monitoring/metrics/

--- a/content/dashboards/widgets/table-widget.md
+++ b/content/dashboards/widgets/table-widget.md
@@ -33,11 +33,6 @@ Set the scope of your Table widget by inserting an element name or by selecting 
 
 ![set-attributes](/images/table-widget/set-attributes.png)
 
-## Email
-Provide an email address to receive regular daily or weekly updates. You can also turn this off using the **Frequency** setting.
-
-![set-email](/images/table-widget/set-email.png)
-
 ## Widget Name
 Provide a widget name and then **Save**.
 


### PR DESCRIPTION
Receive daily or weekly emails that snapshot widget data (limited to the table widget) because this feature has never been implemented