### PR TITLE
consolidated ingest content from metrics api pg

### DIFF
--- a/content/api/api-ingest.md
+++ b/content/api/api-ingest.md
@@ -7,10 +7,24 @@ author: Lawrence Lane
 alwaysopen: false
 pre: ""
 ---
+
+The ingest API allows you to send raw data to CloudWisdom. At least one integration must be set up in your CloudWisdom account to use the ingest endpoint. We recommend using the unique API key (found on the API keys page under the Account Profile drop-down menu) for the Custom integration automatically created for your account as your go-to for anything related to using our API.
+
 This API is used to send CloudWisdom custom data. Two types of custom payloads can be created with this API:
 
 - Custom elements
 - Custom external event messages
+
+## Prerequisites  
+
+To properly use the ingest endpoint, you should first understand the following concepts:
+
+- **Elements**: Elements are the physical or logical components that CloudWisdom monitors. An element can be a physical entity, such as a server or network element, a virtual entity, such as a transaction, or a business entity, such as a company traded on the stock market. Elements are the base component that CloudWisdom uses to analyze metrics and determine the status of your environment.
+- **Metrics**: Metrics are quantifiable measurements whose values are monitored by CloudWisdom and used to assess the performance of an element. Metrics are always associated with one or more elements. Examples of metrics include CPU utilization, Network Bytes Per Second, and Response Time.
+- **Attributes**: Attributes are pieces of metadata associated with elements and/or metrics. Attributes are usually received from an integration. For example, Amazon EBS elements have a variety of attributes, including size, region, createTime (the time stamp when the volume was created), and state.
+- **Samples**: A sample is a raw data value that is delivered from an ingestion service (integration) to CloudWisdom.
+- **Tags**: A tag is a key-value pair that is applied to an entity in CloudWisdom.
+- **Relationships**: A uni- or bi-directional relationship between two elements.
 
 
 ## Custom Payloads
@@ -281,6 +295,142 @@ In the JSON request below, two Elements are passed whose IDs are **webhost01** a
 ]
 ```
 
+## Supported Units
+
+The following tables list all accepted metric units and their corresponding code.
+
+### General
+
+| Code | Unit |
+|-------------|-------------------|
+| short | short |
+| percent | percent (0-100) |
+| percentunit | percent (0.0-1.0) |
+| humidity | Humidity (%H) |
+| ppm | ppm |
+| dB | decibel |
+
+### Data
+
+| Code | Unit |
+|---------|----------------|
+| bits | bits |
+| bytes | bytes (base2) |
+| bytesd | bytes (base10) |
+| kbytes | kilobytes |
+| kibytes | kibibytes |
+| mbytes | megabytes |
+| mibytes | mebibytes |
+| gbytes | gigabytes |
+| gibytes | gibibytes |
+
+### Data rate
+
+| Code | Unit |
+|------|---------------|
+| pps | packets/sec |
+| bps | bits/sec |
+| Bps | bytes/sec |
+| kBps | kilobytes/sec |
+| mBps | megabytes/sec |
+| gBps | gigabytes/sec |
+
+### Time
+
+| Code | Unit |
+|-------|-------------------|
+| hertz | Hertz (1/s) |
+| ns | nanoseconds (ns) |
+| µs | microseconds (µs) |
+| ms | milliseconds (ms) |
+| s | seconds (s) |
+| m | minutes (m) |
+| hours | (h) |
+| d | days (d) |
+
+### Throughput
+
+| Code | Unit |
+|------|-------------------|
+| ops | ops/sec (ops) |
+| rps | reads/sec (rps) |
+| wps | writes/sec (wps) |
+| iops | I/O ops/sec (iops |
+
+### Memory
+
+| Code | Unit |
+|------|------------------|
+| fps | faults/sec (fps) |
+| Pps | pages/sec (Pps) |
+
+### Currency
+
+| Code | Unit |
+|-------------|-------------|
+| currencyUSD | Dollars ($) |
+| currencyGBP | Pounds (£) |
+| currencyEUR | Euro (€) |
+| currencyJPY | Yen (¥) |
+
+### Length
+
+| Code | Unit |
+|----------|-----------------|
+| lengthmm | millimetre (mm) |
+| lengthm | meter (m) |
+| lengthkm | kilometer (km) |
+| lengthmi | mile (mi) |
+
+### Velocity
+
+| Code | Unit |
+|--------------|----------|
+| velocityms | m/s |
+| velocitykmh | km/h |
+| velocitymph | mph |
+| velocityknot | knot (kn |
+
+### Volume
+
+| Code | Unit |
+|--------|-------------|
+| mlitre | millilitre |
+| litre | litre |
+| m3 | cubic metre |
+
+### Energy
+
+| Code | Unit |
+|--------|---------------------|
+| watt | watt (W) |
+| kwatt | kilowatt (kW) |
+| watth | watt-hour (Wh) |
+| kwatth | kilowatt-hour (kWh) |
+| joule | joule (J) |
+| ev | electron volt (eV) |
+| amp | Ampere (A) |
+| volt | Volt (V) |
+
+### Temperature
+
+| Code | Unit |
+|-----------|----------------|
+| celsius | Celcius (°C) |
+| farenheit | Farenheit (°F) |
+| kelvin | Kelvin (K) |
+
+### Pressure
+
+| Code | Unit |
+|--------------|-------------------|
+| pressurembar | Millibars |
+| pressurehpa | Hectopascals |
+| pressurehg | Inches of mercury |
+| pressurepsi | PSI |
+
+---
+
 ## Frequently Asked Questions
 
 ### What is the endpoint to get to Ingest API?
@@ -344,3 +494,45 @@ Yes. Relationships can be added as an array of relations. Relationships can be u
 {{% notice tip %}}
 If you submit an element with `“id” = “webserver01”` that contained a relationship `“fqn”:”load-balancer-east”`, CloudWisdom would create a relationship from **webserver01** to **load-balancer-east**. It would not automatically create a relationship from **load-balander-east** to **webserver01**; however, you can add the inverse relationship to l**oad-balancer-east** via a separate API call.
 {{% /notice %}}
+
+### What is the sparseDataStrategy property?
+Metrics marked as Sparse (with any strategy other than None) that do not receive any samples during the current cycle will get actual and sparseValue data injected for that cycle.
+
+There are 5 sparse strategies:
+
+- **None**: does as you would expect, nothing.  This is the default setting.
+- **ReplaceWithZero**: will inject a value of 0.
+- **ReplaceWithHistoricalMax**: injects the maximum Actual value recorded for the life of this metric.
+- **ReplaceWithHistoricalMin**: injects the minimum Actual value recorded for the life of this metric.
+- **ReplaceWithLast**: injects the last Actual value recorded for this metric.
+
+There are two ways to set the Sparse Data Strategy for a metric.  The first is to send the strategy via the ingest process as Metric Metadata.  The second is using packages.
+
+```
+[{
+  "match": "metric0",
+  "properties": {
+    "sparseDataStrategy": "None"
+  }
+},{
+  "match": "metric1",
+  "properties": {
+    "sparseDataStrategy": "ReplaceWithHistoricalMax"
+  }
+}, {
+  "match": "metric2",
+  "properties": {
+    "sparseDataStrategy": "ReplaceWithHistoricalMin"
+  }
+}, {
+  "match": "metric3",
+  "properties": {
+    "sparseDataStrategy": "ReplaceWithLast"
+  }
+}, {
+  "match": "metric4",
+  "properties": {
+    "sparseDataStrategy": "ReplaceWithZero"
+  }
+}]
+```

--- a/content/api/api-ingest.md
+++ b/content/api/api-ingest.md
@@ -89,6 +89,38 @@ Custom elements can have metrics, tags, attributes, and relationships.
 ]
 
 ```
+### Request Body
+
+| Attribute | Required/Optional | Description |
+|--------------------------------------------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| relations | Optional | Defines a relationship between two elements. It contains one attribute: fqn (optional) The FQN of the element you want to create a relationship with. |
+| id | Required | The FQN of the element. The valid character regex for this field is[a-zA-Z0-9\\._-]. Spaces are replaced with _ and all other invalid characters are removed. |
+| metrics | Required | Tells CloudWisdom which metric you are passing data to. See the Metric Attributes section for more details. |
+| samples | Required | Tells CloudWisdom what data to pass to the metric you defined in the metrics attribute.  Only one of the six sample inputsare required.  Min/max/avg/cnt/sum are sent if aggregation is happening on the client side prior to sending the data to CloudWisdom. Val represents a raw observation of some type. To enable analytics, either send in val by itself or min, max, sum, avg, and cnt. You will not get any bands if you send in min, max, sum, avg, or cnt by itself. See the Sample Attributes section for more details. |  |  |
+| attributes | Optional | The attributes attribute provides CloudWisdom with metadata about the element. You can pass in attributes the same way you would pass in tags: [{“name”:”key1″, “value”:”value1″}, {“name”:”key2″, “value”:”value2″}, (etc.)] |
+| type | Required | The type of element (e.g., server, database, etc.) used for filtering and applying policies in CloudWisdom. |
+| location | Optional | The location of the element is used for filtering and display purposes in CloudWisdom. The location can reflect either the element’s physical location or business needs. |
+| tags | Optional | Used for filtering in CloudWisdom. In the format of [{“name”:”key1″, “value”:”value1″}, {“name”:”key2″, “value”:”value2″}, (etc.)]. |
+| name | Optional | The text displayed as the name for the element in CloudWisdom. |
+
+#### Metric Attributes
+- **id** (required): The unique FQN of the metric (e.g., aws.ec2.cpucreditbalance, cpu.cpu1.guest_nice, diskspace.root.bytefree). The valid character regex for this field is[a-zA-Z0-9\.-]. Spaces are replaced with _ and all other invalid characters are removed.
+- **unit** (optional: Arbitrary value used in the CloudWisdom UI for the metric’s unit of measure.
+- **sparseDataStrategy** (optional): Defines the strategy for replacing missing data. See the sparseDataStrategy Explained section at the bottom of this guide for more information.
+- **type** (optional): Currently only accepts the value “COUNTER” if the metric is a counter type.
+- **tags** (optional): Used for filtering in CloudWisdom. In the format of [{“name”:”key1″, “value”:”value1″}, {“name”:”key2″, “value”:”value2″}, (etc.)]. name (optional) The text displayed as the name for the element in CloudWisdom.
+
+#### Sample Attributes
+
+- **metricId** (required): Mapping to the ID field of the metric for this sample.
+- **timestamp** (required): A number indicating the point in time at which the sample was collected. The timestamp must be either ISO 8601 formatted, or written as an epoch in milliseconds. Ensure that ISO 8601 formatted dates are quoted.
+- **max** (optional):  Maximum value of this metric sample.
+- **avg** (optional):  Average value of this metric sample.
+- **cnt** (optional):  Count of values of this metric sample.
+- **min** (optional):  Minimum value of this metric sample.
+- **sum** (optional):  Sum of values of this metric sample.
+- **val** (optional): The value of the metric; should NOT be sent with other sample inputs.
+
 
 ### Custom External Event Messages
 **POST request**: `https://api.us.cloudwisdom.virtana.com/ingest/events/{apiId}`


### PR DESCRIPTION
moved the following off of metrics api pg to ingest api pg: 

- turned sparsedatastrategy section into a FAQ
- re-purposed custom ingest section into header content on ingest pg
- added supported unit tables