### PR TITLE
Puppetdb remove api key and package references

### DIFF
--- a/content/integrations/puppetdb/_index.md
+++ b/content/integrations/puppetdb/_index.md
@@ -13,13 +13,7 @@ author: Lawrence Lane
 
 You cannot activate the PuppetDB integration until CloudWisdom begins receiving data. Once data arrives, the package ([Dashboards][2] and [Policies][3]) is automatically provisioned. To remove those Dashboards and Policies, click the toggle on the PuppetDB integration card.
 
-### 1. Get API Key
-
-1. In CloudWisdom, Navigate to **Integrations** > **PuppetDB**.
-2. Copy the **API Key**.
-3. Add this key to your Linux Agent.
-
-### 2. Update the Configuration File
+### 1. Update the Configuration File
 
 1. Open **PuppetDBCollector.conf** in the collectors folder, `/opt/netuitive-agent/conf/collectors`.
 2. Change the **enabled** setting to `True`,]

--- a/content/integrations/puppetdb/_index.md
+++ b/content/integrations/puppetdb/_index.md
@@ -11,8 +11,6 @@ author: Lawrence Lane
 
 ## Configure
 
-You cannot activate the PuppetDB integration until CloudWisdom begins receiving data. Once data arrives, the package ([Dashboards][2] and [Policies][3]) is automatically provisioned. To remove those Dashboards and Policies, click the toggle on the PuppetDB integration card.
-
 ### 1. Update the Configuration File
 
 1. Open **PuppetDBCollector.conf** in the collectors folder, `/opt/netuitive-agent/conf/collectors`.


### PR DESCRIPTION
A custom API key is not needed and a package does not exist.