### PR TITLE
Post deprecation deletion api updates

### DIFF
--- a/content/api/api-elements.md
+++ b/content/api/api-elements.md
@@ -329,12 +329,6 @@ The following response body prints a preview of the element name created by merg
 
 ---
 
-## POST to /elements/search
-
-{{< button href="https://app.metricly.com/swagger-ui.html#!/elements/getElementsPOSTUsingPOST" theme="success" >}} POST {{< /button >}} This is a deprecated method. Use **/elements/elasticsearch/elementQuery** instead.
-
----
-
 ## GET from /elements/{elementId}/events
 
 {{< button theme="info" href="https://app.metricly.com/swagger-ui.html#!/elements/getEventsUsingGET" >}} GET {{< /button >}} Use this endpoint to discover events within certain time frames (days, hours, minutes).

--- a/content/api/api-metrics.md
+++ b/content/api/api-metrics.md
@@ -396,7 +396,7 @@ The following response body returns matches for 2 elements that contain the spec
 
 ## GET from /metrics/fqns
 
-{{< button href="https://app.metricly.com/swagger-ui.html#!/metrics/getMetricFqnsUsingGET" theme="info" >}} GET {{< /button >}} Use this endpoint to get a list of metric FQNs for a given set of criteria. Note this is a deprecated method and could be removed at a later date.   
+{{< button href="https://app.metricly.com/swagger-ui.html#!/metrics/getMetricFqnsUsingGET" theme="info" >}} GET {{< /button >}} Use this endpoint to get a list of metric FQNs for a given set of criteria.
 
 {{% expand "View Method Details." %}}
 
@@ -592,7 +592,7 @@ The following response body
 
 ## POST to /metrics/statistics
 
-{{< button href="https://app.metricly.com/swagger-ui.html#!/metrics/getMetricStatisticsPageUsingPOST" theme="success" >}} POST {{< /button >}} Use this endpoint to get metric statistics for given set of elements. Note this is a deprecated method and could be removed at a later date.  
+{{< button href="https://app.metricly.com/swagger-ui.html#!/metrics/getMetricStatisticsPageUsingPOST" theme="success" >}} POST {{< /button >}} Use this endpoint to get metric statistics for given set of elements.
 
 {{% expand "View Method Details." %}}
 


### PR DESCRIPTION
We can add deprecation messages back if we decide to re-deprecate the endpoints.